### PR TITLE
adding code to handle null values for name properties

### DIFF
--- a/src/main/java/unitth/fitnesse/TestItem.java
+++ b/src/main/java/unitth/fitnesse/TestItem.java
@@ -46,6 +46,10 @@ public class TestItem {
 	}
 	
 	public String getName() {
+		if (name == null) {
+			return "module-not-defined";
+		}
+
 		return name;
 	}
 

--- a/src/main/java/unitth/fitnesse/TestItemSummary.java
+++ b/src/main/java/unitth/fitnesse/TestItemSummary.java
@@ -46,6 +46,10 @@ public abstract class TestItemSummary {
 	}
 	
 	public String getName() {
+		if (name == null) {
+			return "module-not-defined";
+		}
+
 		return name;
 	}
 	

--- a/src/main/java/unitth/junit/TestCaseSummary.java
+++ b/src/main/java/unitth/junit/TestCaseSummary.java
@@ -175,6 +175,10 @@ public class TestCaseSummary extends TestItemSummary {
 	 * @return The stripped package name.
 	 */
 	public String getPackageName() {
+		if (name == null) {
+			return "package-not-defined";
+		}
+
 		int liof = className.lastIndexOf(".");
 		if (-1 == liof) {
 			return "not-in-package";

--- a/src/main/java/unitth/junit/TestItem.java
+++ b/src/main/java/unitth/junit/TestItem.java
@@ -81,6 +81,10 @@ public class TestItem {
 	 * @return The name of the test item.
 	 */
 	public String getName() {
+		if (name == null) {
+			return "module-not-defined";
+		}
+
 		return name;
 	}
 
@@ -99,6 +103,10 @@ public class TestItem {
 	 * @return The package part ripped from the full name.
 	 */
 	public String getPackageName() {
+		if (name == null) {
+			return "package-not-defined";
+		}
+
 		int liof = name.lastIndexOf(".");
 		if (-1 == liof) {
 			return "not-in-package";

--- a/src/main/java/unitth/junit/TestItemSummary.java
+++ b/src/main/java/unitth/junit/TestItemSummary.java
@@ -72,6 +72,10 @@ public abstract class TestItemSummary {
 	 * @return The name of the test module or test case stored in this instance.
 	 */
 	public String getName() {
+		if (name == null) {
+			return "module-not-defined";
+		}
+
 		return name;
 	}
 
@@ -188,6 +192,10 @@ public abstract class TestItemSummary {
 	 * @return The stripped package name.
 	 */
 	public String getPackageName() {
+		if (name == null) {
+			return "package-not-defined";
+		}
+
 		int liof = name.lastIndexOf(".");
 		if (-1 == liof) {
 			return "not-in-package";


### PR DESCRIPTION
This PR handles null values in the getName and getPackageName functions.  Primarily it's so that if this property doesn't exist in the xml document, the application won't crash and just input a generic value.